### PR TITLE
Replace account id by wildcard in automation-definition ARN

### DIFF
--- a/source/lib/playbook-construct.ts
+++ b/source/lib/playbook-construct.ts
@@ -377,7 +377,7 @@ export class SsmRemediationRole extends cdk.Construct {
     );
     ssmPerms.addResources(
         'arn:' + stack.partition + ':ssm:' + stack.region + ':' +
-        stack.account + ':automation-definition/*'
+        ':automation-definition/*'
     );
     ssmPerms.addResources(
         'arn:' + stack.partition + ':ssm:' + stack.region + ':' +

--- a/source/lib/playbook-construct.ts
+++ b/source/lib/playbook-construct.ts
@@ -377,7 +377,7 @@ export class SsmRemediationRole extends cdk.Construct {
     );
     ssmPerms.addResources(
         'arn:' + stack.partition + ':ssm:' + stack.region + ':' +
-        ':automation-definition/*'
+        '*:automation-definition/*'
     );
     ssmPerms.addResources(
         'arn:' + stack.partition + ':ssm:' + stack.region + ':' +

--- a/source/playbooks/CIS/lib/cis-permissions-stack.ts
+++ b/source/playbooks/CIS/lib/cis-permissions-stack.ts
@@ -202,7 +202,7 @@ export class CisPermissionsStack extends cdk.Stack {
     );
     cis26ssm.addResources(
         'arn:' + this.partition + ':ssm:' + this.region + ':' +
-        ':automation-definition/*'
+        '*:automation-definition/*'
     );
 
     const cis26s3 = new PolicyStatement();
@@ -355,7 +355,7 @@ export class CisPermissionsStack extends cdk.Stack {
     );
     cis4142ssm.addResources(
         'arn:' + this.partition + ':ssm:' + this.region + ':' +
-        ':automation-definition/*'
+        '*:automation-definition/*'
     );
 
     const cis4142Policy = new PolicyDocument();

--- a/source/playbooks/CIS/lib/cis-permissions-stack.ts
+++ b/source/playbooks/CIS/lib/cis-permissions-stack.ts
@@ -202,7 +202,7 @@ export class CisPermissionsStack extends cdk.Stack {
     );
     cis26ssm.addResources(
         'arn:' + this.partition + ':ssm:' + this.region + ':' +
-        this.account + ':automation-definition/*'
+        ':automation-definition/*'
     );
 
     const cis26s3 = new PolicyStatement();
@@ -355,7 +355,7 @@ export class CisPermissionsStack extends cdk.Stack {
     );
     cis4142ssm.addResources(
         'arn:' + this.partition + ':ssm:' + this.region + ':' +
-        this.account + ':automation-definition/*'
+        ':automation-definition/*'
     );
 
     const cis4142Policy = new PolicyDocument();


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-security-hub-automated-response-and-remediation/issues/26

*Description of changes:*
Replacing account id by wildcard in automation-definition ARN. Expected result in IAM policy statement resources:
`"arn:aws:ssm:<region>:*:automation-definition/*"`

This change has only been tested manually in the AWS console. I don't know if it actually resolves the issue for all of the different controls.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
